### PR TITLE
フォロー解除機能

### DIFF
--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -90,7 +90,7 @@ const FollowButton: FC<FollowButtonProps> = ({
           sx={{ ml: 6 }}
           loading={followLoading}
         >
-          フォロー
+          フォローする
         </LoadingButton>
       )}
     </>

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -80,6 +80,7 @@ const FollowButton: FC<FollowButtonProps> = ({
           variant="outlined"
           sx={{ ml: 6 }}
           loading={unfollowLoading}
+          color={hovered ? 'secondary' : 'primary'}
         >
           {hovered ? 'フォロー解除' : 'フォロー中'}
         </LoadingButton>

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -65,7 +65,7 @@ const FollowButton: FC<FollowButtonProps> = ({
 
   if (loading)
     return (
-      <Button variant="outlined" sx={{ ml: 8 }}>
+      <Button variant="outlined" sx={{ ml: 6 }}>
         Loading...
       </Button>
     );
@@ -78,7 +78,7 @@ const FollowButton: FC<FollowButtonProps> = ({
           onMouseLeave={() => setHovered(false)}
           onClick={() => handleUnfollow(currentUserName, artist.name)}
           variant="outlined"
-          sx={{ ml: 8 }}
+          sx={{ ml: 6 }}
           loading={unfollowLoading}
         >
           {hovered ? 'フォロー解除' : 'フォロー中'}
@@ -87,7 +87,7 @@ const FollowButton: FC<FollowButtonProps> = ({
         <LoadingButton
           onClick={() => handleFollow(currentUserName, artist.name)}
           variant="contained"
-          sx={{ ml: 8 }}
+          sx={{ ml: 6 }}
           loading={followLoading}
         >
           フォロー

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -33,6 +33,7 @@ const FollowButton: FC<FollowButtonProps> = ({
     { unfollow: User },
     FollowArtistInput
   >(unfollowArtistMutation);
+  const [hovered, setHovered] = useState<boolean>(false);
 
   const handleFollow = (userName: string, artistName: string) => {
     follow({
@@ -73,12 +74,14 @@ const FollowButton: FC<FollowButtonProps> = ({
     <>
       {isFollow ? (
         <LoadingButton
+          onMouseEnter={() => setHovered(true)}
+          onMouseLeave={() => setHovered(false)}
           onClick={() => handleUnfollow(currentUserName, artist.name)}
           variant="outlined"
           sx={{ ml: 8 }}
           loading={unfollowLoading}
         >
-          フォロー中
+          {hovered ? 'フォロー解除' : 'フォロー中'}
         </LoadingButton>
       ) : (
         <LoadingButton

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -25,17 +25,17 @@ const FollowButton: FC<FollowButtonProps> = ({
   loading,
 }) => {
   const [isFollow, setIsFollow] = useState<boolean>(false);
-  const [createUserArtistRelationship, { loading: followLoading }] =
-    useMutation<{ createUserArtistRelationship: User }, FollowArtistInput>(
-      followArtistMutation,
-    );
+  const [follow, { loading: followLoading }] = useMutation<
+    { follow: User },
+    FollowArtistInput
+  >(followArtistMutation);
   const [unfollow, { loading: unfollowLoading }] = useMutation<
     { unfollow: User },
     FollowArtistInput
   >(unfollowArtistMutation);
 
   const handleFollow = (userName: string, artistName: string) => {
-    createUserArtistRelationship({
+    follow({
       variables: { userName, artistName },
     })
       .then((_) => {

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -2,7 +2,12 @@ import { FC, useState, useEffect } from 'react';
 import { Artist } from 'lib/artist';
 import { Button } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
-import { FollowArtistInput, followArtistMutation, User } from 'lib/user';
+import {
+  FollowArtistInput,
+  followArtistMutation,
+  User,
+  unfollowArtistMutation,
+} from 'lib/user';
 import { useMutation } from '@apollo/client';
 import toast from 'react-hot-toast';
 
@@ -24,6 +29,10 @@ const FollowButton: FC<FollowButtonProps> = ({
     useMutation<{ createUserArtistRelationship: User }, FollowArtistInput>(
       followArtistMutation,
     );
+  const [unfollow, { loading: unfollowLoading }] = useMutation<
+    { unfollow: User },
+    FollowArtistInput
+  >(unfollowArtistMutation);
 
   const handleFollow = (userName: string, artistName: string) => {
     createUserArtistRelationship({
@@ -34,6 +43,18 @@ const FollowButton: FC<FollowButtonProps> = ({
       })
       .catch((e: Error) => {
         toast.error(`${e.message}`);
+      });
+  };
+
+  const handleUnfollow = (userName: string, artistName: string) => {
+    unfollow({
+      variables: { userName, artistName },
+    })
+      .then((_) => {
+        setIsFollow(false);
+      })
+      .catch((e: Error) => {
+        toast.error(e.message);
       });
   };
 
@@ -51,9 +72,14 @@ const FollowButton: FC<FollowButtonProps> = ({
   return (
     <>
       {isFollow ? (
-        <Button variant="outlined" sx={{ ml: 8 }}>
+        <LoadingButton
+          onClick={() => handleUnfollow(currentUserName, artist.name)}
+          variant="outlined"
+          sx={{ ml: 8 }}
+          loading={unfollowLoading}
+        >
           フォロー中
-        </Button>
+        </LoadingButton>
       ) : (
         <LoadingButton
           onClick={() => handleFollow(currentUserName, artist.name)}

--- a/client/src/lib/user.ts
+++ b/client/src/lib/user.ts
@@ -76,3 +76,19 @@ export const followArtistMutation = gql`
     }
   }
 `;
+
+export const unfollowArtistMutation = gql`
+  mutation DeleteUserArtistRelationship(
+    $userName: String!
+    $artistName: String!
+  ) {
+    deleteUserArtistRelationship(
+      input: { userName: $userName, artistName: $artistName }
+    ) {
+      user {
+        id
+        name
+      }
+    }
+  }
+`;

--- a/server/app/graphql/mutations/delete_user_artist_relationship.rb
+++ b/server/app/graphql/mutations/delete_user_artist_relationship.rb
@@ -12,7 +12,7 @@ module Mutations
     # end
     field :user, Types::UserType, null: true
 
-    argument :user_name, ID, required: true
+    argument :user_name, String, required: true
     argument :artist_name, String, required: true
 
     def resolve(user_name:, artist_name:)


### PR DESCRIPTION
機能
・ボタンにホバーすると、「フォロー中」が「フォロー解除」に切り替わる
・「フォロー中」ボタンを押すとUserArtistモデルのデータを削除
・データ削除中はボタンがloadingモードになる
・データ削除が終わるとボタンが「フォローする」に切り替わる

実装方法
1. 「フォロー中」ボタンを押すとuseMutationが実行される
2. 実行が終わるとisFollowをfalseに変更

補足
ボタンの名前が「フォロー」だと現在アーティストをフォローしているか、していないか、わかりにくく感じることがあったので、「フォローする」に修正