### PR TITLE
Artistページに無限スクロール実装

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,9 @@
 import { FC } from 'react';
-import TopPage from 'pages/TopPage';
-import UserPage from 'pages/UserPage';
-import SignupPage from 'pages/SignupPage';
-import LoginPage from 'pages/LoginPage';
-import ArtistPage from 'pages/ArtistPage';
+import TopPage from 'pages/topPage';
+import UserPage from 'pages/userPage';
+import SignupPage from 'pages/signupPage';
+import LoginPage from 'pages/loginPage';
+import ArtistPage from 'pages/artistPage';
 import Header from 'components/Header';
 import { Route, Routes, Navigate } from 'react-router';
 

--- a/client/src/components/ArtistListElementCard.tsx
+++ b/client/src/components/ArtistListElementCard.tsx
@@ -47,9 +47,9 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
       });
   };
 
-  const handleUnfollow = (userName: string, artistName: string) => {
+  const handleUnfollow = () => {
     unfollow({
-      variables: { userName, artistName },
+      variables: { userName: currentUserName, artistName: artist.name },
     })
       .then((_) => {
         setIsFollow(false);
@@ -80,9 +80,7 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
                   unfollowLoading={unfollowLoading}
                   isFollow={isFollow}
                   handleFollow={handleFollow}
-                  handleUnfollow={() =>
-                    handleUnfollow(currentUserName, artist.name)
-                  }
+                  handleUnfollow={handleUnfollow}
                   isFollowLoading={isFollowLoading}
                 />
               )}

--- a/client/src/components/ArtistListElementCard.tsx
+++ b/client/src/components/ArtistListElementCard.tsx
@@ -35,9 +35,9 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
     FollowArtistInput
   >(unfollowArtistMutation);
 
-  const handleFollow = (userName: string, artistName: string) => {
+  const handleFollow = () => {
     follow({
-      variables: { userName, artistName },
+      variables: { userName: currentUserName, artistName: artist.name },
     })
       .then((_) => {
         setIsFollow(true);
@@ -79,9 +79,7 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
                   followLoading={followLoading}
                   unfollowLoading={unfollowLoading}
                   isFollow={isFollow}
-                  handleFollow={() =>
-                    handleFollow(currentUserName, artist.name)
-                  }
+                  handleFollow={handleFollow}
                   handleUnfollow={() =>
                     handleUnfollow(currentUserName, artist.name)
                   }

--- a/client/src/components/ArtistListElementCard.tsx
+++ b/client/src/components/ArtistListElementCard.tsx
@@ -1,7 +1,15 @@
-import { FC } from 'react';
+import { FC, useState, useEffect } from 'react';
 import { Artist } from 'lib/artist';
 import { Card, CardContent, Typography, Grid } from '@mui/material';
 import FollowButton from 'components/FollowButton';
+import {
+  FollowArtistInput,
+  followArtistMutation,
+  User,
+  unfollowArtistMutation,
+} from 'lib/user';
+import { useMutation } from '@apollo/client';
+import toast from 'react-hot-toast';
 
 type ArtistListElementCardProps = {
   artist: Artist;
@@ -15,28 +23,81 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
   currentUserArtistsName,
   loading,
   currentUserName,
-}) => (
-  <Grid item xs={6}>
-    <Card sx={{ width: 550, backgroundColor: '#e1f5fe', m: 2 }}>
-      <CardContent>
-        <Grid container>
-          <Grid item sm={8}>
-            <Typography variant="h5">{artist.name}</Typography>
+}) => {
+  const [isFollow, setIsFollow] = useState<boolean>(false);
+  const [isFollowLoading, setIsFollowLoading] = useState<boolean>(true);
+  const [follow, { loading: followLoading }] = useMutation<
+    { follow: User },
+    FollowArtistInput
+  >(followArtistMutation);
+  const [unfollow, { loading: unfollowLoading }] = useMutation<
+    { unfollow: User },
+    FollowArtistInput
+  >(unfollowArtistMutation);
+
+  const handleFollow = (userName: string, artistName: string) => {
+    follow({
+      variables: { userName, artistName },
+    })
+      .then((_) => {
+        setIsFollow(true);
+      })
+      .catch((e: Error) => {
+        toast.error(`${e.message}`);
+      });
+  };
+
+  const handleUnfollow = (userName: string, artistName: string) => {
+    unfollow({
+      variables: { userName, artistName },
+    })
+      .then((_) => {
+        setIsFollow(false);
+      })
+      .catch((e: Error) => {
+        toast.error(e.message);
+      });
+  };
+
+  useEffect(() => {
+    setIsFollowLoading(true);
+  }, []);
+
+  useEffect(() => {
+    if (currentUserArtistsName?.has(artist.name)) setIsFollow(true);
+    setIsFollowLoading(false);
+  }, [artist, currentUserArtistsName]);
+
+  return (
+    <Grid item xs={6}>
+      <Card sx={{ width: 550, backgroundColor: '#e1f5fe', m: 2 }}>
+        <CardContent>
+          <Grid container>
+            <Grid item sm={8}>
+              <Typography variant="h5">{artist.name}</Typography>
+            </Grid>
+            <Grid item sm={4}>
+              {currentUserName && (
+                <FollowButton
+                  loading={loading}
+                  followLoading={followLoading}
+                  unfollowLoading={unfollowLoading}
+                  isFollow={isFollow}
+                  handleFollow={() =>
+                    handleFollow(currentUserName, artist.name)
+                  }
+                  handleUnfollow={() =>
+                    handleUnfollow(currentUserName, artist.name)
+                  }
+                  isFollowLoading={isFollowLoading}
+                />
+              )}
+            </Grid>
           </Grid>
-          <Grid item sm={4}>
-            {currentUserName && (
-              <FollowButton
-                artist={artist}
-                currentUserArtistsName={currentUserArtistsName}
-                loading={loading}
-                currentUserName={currentUserName}
-              />
-            )}
-          </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
-  </Grid>
-);
+        </CardContent>
+      </Card>
+    </Grid>
+  );
+};
 
 export default ArtistListElementCard;

--- a/client/src/components/ArtistListElementCard.tsx
+++ b/client/src/components/ArtistListElementCard.tsx
@@ -5,14 +5,14 @@ import FollowButton from 'components/FollowButton';
 
 type ArtistListElementCardProps = {
   artist: Artist;
-  currentUserArtists: Set<Artist>;
+  currentUserArtistsName: Set<string>;
   loading: boolean;
   currentUserName: string;
 };
 
 const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
   artist,
-  currentUserArtists,
+  currentUserArtistsName,
   loading,
   currentUserName,
 }) => (
@@ -27,7 +27,7 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
             {currentUserName && (
               <FollowButton
                 artist={artist}
-                currentUserArtists={currentUserArtists}
+                currentUserArtistsName={currentUserArtistsName}
                 loading={loading}
                 currentUserName={currentUserName}
               />

--- a/client/src/components/ArtistListElementCard.tsx
+++ b/client/src/components/ArtistListElementCard.tsx
@@ -60,10 +60,6 @@ const ArtistListElementCard: FC<ArtistListElementCardProps> = ({
   };
 
   useEffect(() => {
-    setIsFollowLoading(true);
-  }, []);
-
-  useEffect(() => {
     if (currentUserArtistsName?.has(artist.name)) setIsFollow(true);
     setIsFollowLoading(false);
   }, [artist, currentUserArtistsName]);

--- a/client/src/components/ArtistsCard.tsx
+++ b/client/src/components/ArtistsCard.tsx
@@ -13,9 +13,9 @@ type ArtistsCardProps = {
 
 const ArtistsCard: FC<ArtistsCardProps> = ({ artists }) => {
   const [currentUserName, setCurrentUserName] = useState<string>('');
-  const [currentUserArtists, setCurrentUserArtists] = useState<Set<Artist>>(
-    new Set(),
-  );
+  const [currentUserArtistsName, setCurrentUserArtistsName] = useState<
+    Set<string>
+  >(new Set());
   const [loading, setLoading] = useState<boolean>(true);
   const { refetch } = useQuery<{ userByName: User }, UserByNameInput>(
     getUserByNameQuery,
@@ -32,7 +32,9 @@ const ArtistsCard: FC<ArtistsCardProps> = ({ artists }) => {
     if (currentUserName) {
       refetch()
         .then((res) => {
-          setCurrentUserArtists(new Set(res.data.userByName.artists));
+          setCurrentUserArtistsName(
+            new Set(res.data.userByName.artists.map((artist) => artist.name)),
+          );
           setLoading(false);
         })
         .catch((e: ApolloError) => {
@@ -47,7 +49,7 @@ const ArtistsCard: FC<ArtistsCardProps> = ({ artists }) => {
         <ArtistListElementCard
           key={artist.id}
           artist={artist}
-          currentUserArtists={currentUserArtists}
+          currentUserArtistsName={currentUserArtistsName}
           loading={loading}
           currentUserName={currentUserName}
         />

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -13,13 +13,13 @@ import toast from 'react-hot-toast';
 
 type FollowButtonProps = {
   currentUserName: string;
-  currentUserArtists: Set<Artist>;
+  currentUserArtistsName: Set<string>;
   artist: Artist;
   loading: boolean;
 };
 
 const FollowButton: FC<FollowButtonProps> = ({
-  currentUserArtists,
+  currentUserArtistsName,
   currentUserName,
   artist,
   loading,
@@ -60,8 +60,8 @@ const FollowButton: FC<FollowButtonProps> = ({
   };
 
   useEffect(() => {
-    if (currentUserArtists?.has(artist)) setIsFollow(true);
-  }, [artist, currentUserArtists]);
+    if (currentUserArtistsName?.has(artist.name)) setIsFollow(true);
+  }, [artist, currentUserArtistsName]);
 
   if (loading)
     return (

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -1,70 +1,29 @@
-import { FC, useState, useEffect } from 'react';
-import { Artist } from 'lib/artist';
+import { FC, useState } from 'react';
 import { Button, CircularProgress } from '@mui/material';
 import LoadingButton from '@mui/lab/LoadingButton';
-import {
-  FollowArtistInput,
-  followArtistMutation,
-  User,
-  unfollowArtistMutation,
-} from 'lib/user';
-import { useMutation } from '@apollo/client';
-import toast from 'react-hot-toast';
 
 type FollowButtonProps = {
-  currentUserName: string;
-  currentUserArtistsName: Set<string>;
-  artist: Artist;
   loading: boolean;
+  followLoading: boolean;
+  unfollowLoading: boolean;
+  isFollow: boolean;
+  handleFollow: () => void;
+  handleUnfollow: () => void;
+  isFollowLoading: boolean;
 };
 
 const FollowButton: FC<FollowButtonProps> = ({
-  currentUserArtistsName,
-  currentUserName,
-  artist,
   loading,
+  followLoading,
+  unfollowLoading,
+  isFollow,
+  handleFollow,
+  handleUnfollow,
+  isFollowLoading,
 }) => {
-  const [isFollow, setIsFollow] = useState<boolean>();
-  const [follow, { loading: followLoading }] = useMutation<
-    { follow: User },
-    FollowArtistInput
-  >(followArtistMutation);
-  const [unfollow, { loading: unfollowLoading }] = useMutation<
-    { unfollow: User },
-    FollowArtistInput
-  >(unfollowArtistMutation);
   const [hovered, setHovered] = useState<boolean>(false);
 
-  const handleFollow = (userName: string, artistName: string) => {
-    follow({
-      variables: { userName, artistName },
-    })
-      .then((_) => {
-        setIsFollow(true);
-      })
-      .catch((e: Error) => {
-        toast.error(`${e.message}`);
-      });
-  };
-
-  const handleUnfollow = (userName: string, artistName: string) => {
-    unfollow({
-      variables: { userName, artistName },
-    })
-      .then((_) => {
-        setIsFollow(false);
-      })
-      .catch((e: Error) => {
-        toast.error(e.message);
-      });
-  };
-
-  useEffect(() => {
-    if (currentUserArtistsName?.has(artist.name)) setIsFollow(true);
-    else setIsFollow(false);
-  }, [artist, currentUserArtistsName]);
-
-  if (isFollow === undefined || loading)
+  if (isFollowLoading || loading)
     return (
       <Button variant="outlined" sx={{ ml: 6 }}>
         <CircularProgress size={24.5} color="inherit" />
@@ -77,7 +36,7 @@ const FollowButton: FC<FollowButtonProps> = ({
         <LoadingButton
           onMouseEnter={() => setHovered(true)}
           onMouseLeave={() => setHovered(false)}
-          onClick={() => handleUnfollow(currentUserName, artist.name)}
+          onClick={handleUnfollow}
           variant="outlined"
           sx={{ ml: 6 }}
           loading={unfollowLoading}
@@ -87,7 +46,7 @@ const FollowButton: FC<FollowButtonProps> = ({
         </LoadingButton>
       ) : (
         <LoadingButton
-          onClick={() => handleFollow(currentUserName, artist.name)}
+          onClick={handleFollow}
           variant="contained"
           sx={{ ml: 6 }}
           loading={followLoading}

--- a/client/src/components/FollowButton.tsx
+++ b/client/src/components/FollowButton.tsx
@@ -24,7 +24,7 @@ const FollowButton: FC<FollowButtonProps> = ({
   artist,
   loading,
 }) => {
-  const [isFollow, setIsFollow] = useState<boolean>(false);
+  const [isFollow, setIsFollow] = useState<boolean>();
   const [follow, { loading: followLoading }] = useMutation<
     { follow: User },
     FollowArtistInput
@@ -61,9 +61,10 @@ const FollowButton: FC<FollowButtonProps> = ({
 
   useEffect(() => {
     if (currentUserArtistsName?.has(artist.name)) setIsFollow(true);
+    else setIsFollow(false);
   }, [artist, currentUserArtistsName]);
 
-  if (loading)
+  if (isFollow === undefined || loading)
     return (
       <Button variant="outlined" sx={{ ml: 6 }}>
         <CircularProgress size={24.5} color="inherit" />

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -11,6 +11,7 @@ const cache = new InMemoryCache({
     Query: {
       fields: {
         users: offsetLimitPagination(),
+        artists: offsetLimitPagination(),
       },
     },
   },

--- a/client/src/lib/artist.ts
+++ b/client/src/lib/artist.ts
@@ -14,8 +14,8 @@ export type createArtistInput = {
 };
 
 export const getArtistsQuery = gql`
-  query Artists {
-    artists {
+  query Artists($offset: Int, $limit: Int) {
+    artists(offset: $offset, limit: $limit) {
       id
       name
     }

--- a/client/src/lib/artist.ts
+++ b/client/src/lib/artist.ts
@@ -14,7 +14,7 @@ export type createArtistInput = {
 };
 
 export const getArtistsQuery = gql`
-  query Artists($offset: Int, $limit: Int) {
+  query Artists($offset: Int!, $limit: Int!) {
     artists(offset: $offset, limit: $limit) {
       id
       name

--- a/client/src/lib/user.ts
+++ b/client/src/lib/user.ts
@@ -25,7 +25,7 @@ export type FollowArtistInput = {
 };
 
 export const getUsersQuery = gql`
-  query Users($offset: Int, $limit: Int) {
+  query Users($offset: Int!, $limit: Int!) {
     users(offset: $offset, limit: $limit) {
       id
       name

--- a/client/src/pages/artistPage.tsx
+++ b/client/src/pages/artistPage.tsx
@@ -1,5 +1,5 @@
-import React, { FC, useState, useEffect } from 'react';
-import { useQuery, useMutation } from '@apollo/client';
+import React, { FC, useState } from 'react';
+import { useQuery, useMutation, ApolloError } from '@apollo/client';
 import ArtistsCard from 'components/ArtistsCard';
 import {
   ArtistsData,
@@ -10,15 +10,29 @@ import {
 } from 'lib/artist';
 import { Button, Input, Grid, CircularProgress, Box } from '@mui/material';
 import toast, { Toaster } from 'react-hot-toast';
+import InfiniteScroll from 'react-infinite-scroller';
 
 const ArtistPage: FC = () => {
-  const { loading, data, refetch } = useQuery<ArtistsData>(getArtistsQuery);
+  const [artists, setArtists] = useState<Artist[]>([]);
+  const [value, setValue] = useState<string>('');
+  const [hasMore, setHasMore] = useState<boolean>(true);
+  const { loading, data, fetchMore } = useQuery<ArtistsData>(getArtistsQuery, {
+    variables: {
+      offset: 0,
+      limit: 20,
+    },
+    onCompleted: (res) => {
+      if (res) {
+        setArtists(res.artists);
+      }
+    },
+  });
   const [createArtist] = useMutation<
     { createArtist: Artist },
     createArtistInput
   >(createArtistMutation);
-  const [artists, setArtists] = useState<Artist[]>([]);
-  const [value, setValue] = useState<string>('');
+
+  console.log(artists);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
@@ -28,18 +42,10 @@ const ArtistPage: FC = () => {
     const toastArtistId = toast.loading('Loading...');
     createArtist({ variables: { name: value } })
       .then((_) => {
-        refetch()
-          .then((res) => {
-            setArtists(res.data.artists);
-            toast.success('Artist Created', {
-              id: toastArtistId,
-            });
-          })
-          .catch((e: Error) => {
-            toast.error(`${e.message}`, {
-              id: toastArtistId,
-            });
-          });
+        toast.success('Artist Created', {
+          id: toastArtistId,
+        });
+        setHasMore(true);
       })
       .catch((e: Error) => {
         toast.error(`${e.message}`, {
@@ -49,11 +55,18 @@ const ArtistPage: FC = () => {
     setValue('');
   };
 
-  useEffect(() => {
-    if (data) {
-      setArtists(data.artists);
-    }
-  }, [data]);
+  const getArtistsData = () => {
+    fetchMore({
+      variables: { offset: data?.artists.length || 0 },
+    })
+      .then((res) => {
+        if (res.data.artists.length === 0) setHasMore(false);
+        setArtists((prev) => [...prev, ...res.data.artists]);
+      })
+      .catch((e: ApolloError) => {
+        toast.error(e.message);
+      });
+  };
 
   if (loading)
     return (
@@ -74,7 +87,19 @@ const ArtistPage: FC = () => {
         登録
       </Button>
       <Grid container justifyContent="center">
-        <ArtistsCard artists={artists} />
+        <InfiniteScroll
+          loadMore={getArtistsData}
+          hasMore={hasMore}
+          loader={
+            <div key={0}>
+              {' '}
+              <CircularProgress sx={{ mt: 5, ml: 72 }} />
+            </div>
+          }
+          initialLoad={false}
+        >
+          <ArtistsCard artists={artists} />
+        </InfiniteScroll>
       </Grid>
     </>
   );

--- a/client/src/pages/artistPage.tsx
+++ b/client/src/pages/artistPage.tsx
@@ -16,23 +16,24 @@ const ArtistPage: FC = () => {
   const [artists, setArtists] = useState<Artist[]>([]);
   const [value, setValue] = useState<string>('');
   const [hasMore, setHasMore] = useState<boolean>(true);
-  const { loading, data, fetchMore } = useQuery<ArtistsData>(getArtistsQuery, {
-    variables: {
-      offset: 0,
-      limit: 20,
+  const { error, loading, data, fetchMore } = useQuery<ArtistsData>(
+    getArtistsQuery,
+    {
+      variables: {
+        offset: 0,
+        limit: 20,
+      },
+      onCompleted: (res) => {
+        if (res) {
+          setArtists(res.artists);
+        }
+      },
     },
-    onCompleted: (res) => {
-      if (res) {
-        setArtists(res.artists);
-      }
-    },
-  });
+  );
   const [createArtist] = useMutation<
     { createArtist: Artist },
     createArtistInput
   >(createArtistMutation);
-
-  console.log(artists);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     setValue(event.target.value);
@@ -74,6 +75,7 @@ const ArtistPage: FC = () => {
         <CircularProgress />
       </Box>
     );
+  if (error) return <>Error: {error.message}</>;
 
   return (
     <>

--- a/client/src/pages/topPage.tsx
+++ b/client/src/pages/topPage.tsx
@@ -9,7 +9,7 @@ import InfiniteScroll from 'react-infinite-scroller';
 
 const TopPage: FC = () => {
   const [users, setUsers] = useState<User[]>([]);
-  const [hasMore, setHasMore] = useState(true);
+  const [hasMore, setHasMore] = useState<boolean>(true);
 
   const { loading, error, fetchMore, data } = useQuery<UsersData>(
     getUsersQuery,

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -7,8 +7,8 @@ module Types
     # Add root-level fields here.
     # They will be entry points for queries on your schema.
     field :users, [Types::UserType], null: false do
-      argument :offset, Int, required: false
-      argument :limit, Int, required: false
+      argument :offset, Int, required: true
+      argument :limit, Int, required: true
     end
     def users(offset:, limit:)
       User.includes(:artists).limit(limit).offset(offset)

--- a/server/app/graphql/types/query_type.rb
+++ b/server/app/graphql/types/query_type.rb
@@ -25,9 +25,12 @@ module Types
       end
     end
 
-    field :artists, [Types::ArtistType], null: false
-    def artists
-      Artist.all
+    field :artists, [Types::ArtistType], null: false do
+      argument :offset, Int, required: true
+      argument :limit, Int, required: true
+    end
+    def artists(offset:, limit:)
+      Artist.limit(limit).offset(offset)
     end
 
     # TODO: remove me


### PR DESCRIPTION
機能
・初回レンダリング時、Artistページにアーティストを20件表示
・下にスクロールするとアーティストが20件ずつ取得されていき、取得するデータがなくなるとスクロール不可
・他のページに移動しても取得したアーティストデータは保たれる(更新したら消える)

実装方法
1. serverで、指定した位置(offset)から任意の個数(limit)のアーティストを取得できるよう修正
2. useQueryのfetchMore関数を使い、GraphQLからデータを一定の個数ずつ取得できるようにする
3. InfiniteScrollでスクロール時に実施する関数、スクロール終了の条件を設定

補足
・全データ取得後に新規アーティストを作成しても`hasMore`が`false`になっているため、新規作成したデータが表示されなかった。これを解決するために、新規データ作成後に`hasMore`を`true`に設定している
・`currentUserArtists?.has(artist)`の結果が、fetchMoreで取得したアーティストをフォローしていても`false`になっていた。これを解決するために、`currentUserArtists`を`Artist`オブジェクトから`string`で管理するよう変更(連想配列は同じ内容でも異なるオブジェクトとなるのが原因。しかし、fetchMoreで取得するデータ以外は正常に動作していた。apolloのキャッシュにより同じデータを取得した際には、同じオブジェクトとして管理していた？)
・`fetchMore`には`loading`のようなデータ取得中の状態を管理する方法がないため、`isFollow`の初期値を`undefined`にすることでローディングアイコンを表示するようにした